### PR TITLE
Fix tests for JDK 8 compatibility

### DIFF
--- a/src/test/java/com/example/transformer/UnicodeTest.java
+++ b/src/test/java/com/example/transformer/UnicodeTest.java
@@ -18,6 +18,6 @@ public class UnicodeTest {
         ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         streamer.transform(in, out);
-        assertEquals("{\"msg\":\"🐨\"}", out.toString(StandardCharsets.UTF_8));
+        assertEquals("{\"msg\":\"🐨\"}", new String(out.toByteArray(), StandardCharsets.UTF_8));
     }
 }

--- a/src/test/java/com/example/transformer/XmlToJsonStreamerTest.java
+++ b/src/test/java/com/example/transformer/XmlToJsonStreamerTest.java
@@ -37,6 +37,6 @@ public class XmlToJsonStreamerTest {
         ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         streamer.transform(in, out);
-        return out.toString(StandardCharsets.UTF_8);
+        return new String(out.toByteArray(), StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## Summary
- rewrite ByteArrayOutputStream usages to be compatible with Java 8

## Testing
- `mvn -v` *(fails: command not found)*