### PR TITLE
Add CI workflow and test for comments

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,19 @@
+name: Maven Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: '17'
+    - name: Build with Maven
+      run: mvn -B test

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project provides a Spring Boot service that converts arbitrary XML document
 
 Run tests:
 
+The repository includes a GitHub Actions workflow to automatically run these tests on every push and pull request.
+
 ```bash
 mvn clean test
 ```
@@ -27,4 +29,6 @@ POST XML to `/transform` and receive the mapped JSON.
 * Comments and processing instructions are ignored.
 * Namespace prefixes are preserved.
 * Values remain strings.
+
+The tests also cover unicode handling, repeated siblings and ignoring XML comments.
 

--- a/src/test/java/com/example/transformer/CommentsAndPITest.java
+++ b/src/test/java/com/example/transformer/CommentsAndPITest.java
@@ -1,0 +1,23 @@
+package com.example.transformer;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CommentsAndPITest {
+
+    private final XmlToJsonStreamer streamer = new XmlToJsonStreamer();
+
+    @Test
+    public void commentsAndProcessingInstructionsAreIgnored() throws Exception {
+        String xml = "<?xml version=\"1.0\"?><a><!-- c --><![CDATA[x]]><?pi hi?></a>";
+        ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        streamer.transform(in, out);
+        assertEquals("{\"a\":\"x\"}", out.toString());
+    }
+}


### PR DESCRIPTION
## Summary
- set up a basic GitHub Actions workflow to run `mvn test`
- verify that comments and processing instructions are ignored
- mention automated CI and extra test coverage in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*