### PR TITLE
Add in-memory audit trail with YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The tests also cover unicode handling, repeated siblings and ignoring XML commen
 
 ### Configuration
 
-`MappingConfig` exposes the following properties which can be overridden via `application.properties`:
+`MappingConfig` exposes the following properties which can be overridden via `application.yml`:
 
 ```
 mapping.attribute-prefix=@
@@ -43,4 +43,20 @@ mapping.arrays-for-repeated-siblings=true
 ```
 
 These allow customizing how attributes, text content and repeated elements are represented in the produced JSON.
+
+### Audit History
+
+The service keeps a bounded in-memory history of recent transformations. The history size,
+page size for the HTML views and whether the stored payloads are compressed can be configured
+using the following properties:
+
+```
+audit.history-size=100
+audit.page-size=20
+audit.compress=true
+```
+
+Environment specific variants of `application.yml` can be placed alongside the default file
+using the naming convention `application-{profile}.yml` (e.g. `application-dev.yml`). The active
+profile is selected via the standard Spring Boot `spring.profiles.active` property.
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.17.2</version>
@@ -40,9 +44,6 @@
             <version>7.1.0</version>
         </dependency>
         <dependency>
-            <groupId>de.odysseus.staxon</groupId>
-            <artifactId>staxon</artifactId>
-            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/transformer/AuditController.java
+++ b/src/main/java/com/example/transformer/AuditController.java
@@ -1,0 +1,39 @@
+package com.example.transformer;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.io.IOException;
+
+@Controller
+public class AuditController {
+    private final AuditService service;
+    private final AuditProperties props;
+
+    public AuditController(AuditService service, AuditProperties props) {
+        this.service = service;
+        this.props = props;
+    }
+
+    @GetMapping(value = "/audit", produces = MediaType.TEXT_HTML_VALUE)
+    public String list(@RequestParam(name = "page", defaultValue = "0") int page, Model model) {
+        model.addAttribute("entries", service.page(page, props.getPageSize()));
+        model.addAttribute("page", page);
+        model.addAttribute("pageSize", props.getPageSize());
+        return "auditList";
+    }
+
+    @GetMapping(value = "/audit/{id}", produces = MediaType.TEXT_HTML_VALUE)
+    public String detail(@PathVariable("id") long id, Model model) throws IOException {
+        AuditEntry entry = service.get(id);
+        if (entry == null) {
+            return "auditDetail";
+        }
+        model.addAttribute("entry", entry);
+        return "auditDetail";
+    }
+}

--- a/src/main/java/com/example/transformer/AuditEntry.java
+++ b/src/main/java/com/example/transformer/AuditEntry.java
@@ -1,0 +1,80 @@
+package com.example.transformer;
+
+import java.io.*;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class AuditEntry {
+    private final long id;
+    private final String clientIp;
+    private final long requestTime;
+    private final long responseTime;
+    private final boolean success;
+    private final long durationMs;
+    private final byte[] xmlData;
+    private final byte[] jsonData;
+    private final boolean compressed;
+
+    public AuditEntry(long id, String clientIp, long requestTime, long responseTime, boolean success,
+                      long durationMs, byte[] xmlData, byte[] jsonData, boolean compressed) {
+        this.id = id;
+        this.clientIp = clientIp;
+        this.requestTime = requestTime;
+        this.responseTime = responseTime;
+        this.success = success;
+        this.durationMs = durationMs;
+        this.xmlData = xmlData;
+        this.jsonData = jsonData;
+        this.compressed = compressed;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public long getRequestTime() {
+        return requestTime;
+    }
+
+    public long getResponseTime() {
+        return responseTime;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public long getDurationMs() {
+        return durationMs;
+    }
+
+    public String getXml() throws IOException {
+        return new String(decompress(xmlData), java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    public String getJson() throws IOException {
+        return new String(decompress(jsonData), java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    private byte[] decompress(byte[] data) throws IOException {
+        if (!compressed) {
+            return data;
+        }
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(data);
+             GZIPInputStream gis = new GZIPInputStream(bis)) {
+            return gis.readAllBytes();
+        }
+    }
+
+    public static byte[] compress(byte[] data) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
+            gzip.write(data);
+        }
+        return bos.toByteArray();
+    }
+}

--- a/src/main/java/com/example/transformer/AuditProperties.java
+++ b/src/main/java/com/example/transformer/AuditProperties.java
@@ -1,0 +1,34 @@
+package com.example.transformer;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "audit")
+public class AuditProperties {
+    private int historySize = 100;
+    private int pageSize = 20;
+    private boolean compress = true;
+
+    public int getHistorySize() {
+        return historySize;
+    }
+
+    public void setHistorySize(int historySize) {
+        this.historySize = historySize;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public boolean isCompress() {
+        return compress;
+    }
+
+    public void setCompress(boolean compress) {
+        this.compress = compress;
+    }
+}

--- a/src/main/java/com/example/transformer/AuditService.java
+++ b/src/main/java/com/example/transformer/AuditService.java
@@ -1,0 +1,61 @@
+package com.example.transformer;
+
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+@Service
+public class AuditService {
+    private final Deque<AuditEntry> history = new ArrayDeque<>();
+    private final int maxHistory;
+    private final boolean compress;
+    private final AtomicLong counter = new AtomicLong();
+
+    public AuditService(AuditProperties props) {
+        this.maxHistory = props.getHistorySize();
+        this.compress = props.isCompress();
+    }
+
+    public void add(String clientIp, long start, long end, boolean success, byte[] xml, byte[] json) {
+        try {
+            byte[] x = compress ? AuditEntry.compress(xml) : xml;
+            byte[] j = compress ? AuditEntry.compress(json) : json;
+            AuditEntry entry = new AuditEntry(counter.incrementAndGet(), clientIp, start, end,
+                    success, end - start, x, j, compress);
+            synchronized (history) {
+                if (history.size() >= maxHistory) {
+                    history.removeFirst();
+                }
+                history.addLast(entry);
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+    }
+
+    public List<AuditEntry> page(int page, int size) {
+        synchronized (history) {
+            return history.stream()
+                    .skip((long) page * size)
+                    .limit(size)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+    }
+
+    public AuditEntry get(long id) {
+        synchronized (history) {
+            for (AuditEntry e : history) {
+                if (e.getId() == id) {
+                    return e;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/transformer/TransformController.java
+++ b/src/main/java/com/example/transformer/TransformController.java
@@ -11,33 +11,49 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
 
 @RestController
 @RequestMapping("/transform")
 public class TransformController {
 
     private final XmlToJsonStreamer streamer;
+    private final AuditService auditService;
 
-    public TransformController(XmlToJsonStreamer streamer) {
+    public TransformController(XmlToJsonStreamer streamer, AuditService auditService) {
         this.streamer = streamer;
+        this.auditService = auditService;
     }
 
     @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE},
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<StreamingResponseBody> transform(HttpServletRequest request) throws IOException {
+        long start = System.currentTimeMillis();
+        String clientIp = request.getRemoteAddr();
+
+        byte[] xmlBytes = request.getInputStream().readAllBytes();
+        ByteArrayInputStream xmlInput = new ByteArrayInputStream(xmlBytes);
+
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        boolean success = false;
         try {
-            streamer.transform(request.getInputStream(), buffer);
+            streamer.transform(xmlInput, buffer);
+            success = true;
         } catch (XMLStreamException e) {
             StreamingResponseBody errBody = out -> out.write("{\"error\":\"Malformed XML\"}".getBytes());
+            auditService.add(clientIp, start, System.currentTimeMillis(), false, xmlBytes, errBody.toString().getBytes());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON).body(errBody);
         } catch (IOException e) {
             StreamingResponseBody errBody = out -> out.write(("{\"error\":\"" + e.getMessage() + "\"}").getBytes());
+            auditService.add(clientIp, start, System.currentTimeMillis(), false, xmlBytes, errBody.toString().getBytes());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(MediaType.APPLICATION_JSON).body(errBody);
         }
 
         byte[] json = buffer.toByteArray();
+        long end = System.currentTimeMillis();
+        auditService.add(clientIp, start, end, success, xmlBytes, json);
         StreamingResponseBody body = out -> out.write(json);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(body);
     }

--- a/src/main/java/com/example/transformer/XmlJsonTransformerApplication.java
+++ b/src/main/java/com/example/transformer/XmlJsonTransformerApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties(MappingConfig.class)
+@EnableConfigurationProperties({MappingConfig.class, AuditProperties.class})
 public class XmlJsonTransformerApplication {
     public static void main(String[] args) {
         SpringApplication.run(XmlJsonTransformerApplication.class, args);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,1 @@
+audit:\n  page-size: 10

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,1 @@
+audit:\n  page-size: 10

--- a/src/main/resources/application-sit.yml
+++ b/src/main/resources/application-sit.yml
@@ -1,0 +1,1 @@
+audit:\n  page-size: 10

--- a/src/main/resources/application-uat.yml
+++ b/src/main/resources/application-uat.yml
@@ -1,0 +1,1 @@
+audit:\n  page-size: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+audit:
+  history-size: 100
+  page-size: 20
+  compress: true

--- a/src/main/resources/templates/auditDetail.html
+++ b/src/main/resources/templates/auditDetail.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head><title>Audit Detail</title>
+<style>
+pre {border:1px solid #ccc; padding:10px; overflow:auto;}
+.container {display:flex;}
+.column {flex:1; margin-right:10px;}
+</style>
+</head>
+<body>
+<h2 th:text="'Entry ' + ${entry.id}"></h2>
+<div class="container">
+<div class="column">
+<h3>XML</h3>
+<pre th:text="${entry.xml}"></pre>
+</div>
+<div class="column">
+<h3>JSON</h3>
+<pre th:text="${entry.json}"></pre>
+</div>
+</div>
+<ul>
+<li><b>Client:</b> <span th:text="${entry.clientIp}"></span></li>
+<li><b>Request:</b> <span th:text="${#dates.format(entry.requestTime, 'yyyy-MM-dd HH:mm:ss')}"></span></li>
+<li><b>Response:</b> <span th:text="${#dates.format(entry.responseTime, 'yyyy-MM-dd HH:mm:ss')}"></span></li>
+<li><b>Duration:</b> <span th:text="${entry.durationMs}"></span> ms</li>
+<li><b>Status:</b> <span th:text="${entry.success}"></span></li>
+</ul>
+<a href="/audit">Back to list</a>
+</body>
+</html>

--- a/src/main/resources/templates/auditList.html
+++ b/src/main/resources/templates/auditList.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head><title>Audit History</title></head>
+<body>
+<table border="1">
+<tr><th>ID</th><th>Client IP</th><th>Request Time</th><th>Status</th></tr>
+<tr th:each="e : ${entries}">
+<td><a th:href="@{'/audit/' + ${e.id}}" th:text="${e.id}">1</a></td>
+<td th:text="${e.clientIp}">ip</td>
+<td th:text="${#dates.format(e.requestTime, 'yyyy-MM-dd HH:mm:ss')}">time</td>
+<td th:text="${e.success}">true</td>
+</tr>
+</table>
+<div>
+<a th:if="${page > 0}" th:href="@{'/audit?page=' + ${page - 1}}">Prev</a>
+<a th:if="${entries.size() == pageSize}" th:href="@{'/audit?page=' + ${page + 1}}">Next</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- use YAML config files for runtime properties
- record recent XML->JSON transformations in memory
- expose HTML pages to view audit history and details
- register AuditProperties and use them in the application
- add Thymeleaf and remove unused Staxon dependency

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a87221b78832ea057e8790849e45e