### PR TITLE
Add home page, build metadata and OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,10 @@ Environment specific variants of `application.yml` can be placed alongside the d
 using the naming convention `application-{profile}.yml` (e.g. `application-dev.yml`). The active
 profile is selected via the standard Spring Boot `spring.profiles.active` property.
 
+### Home Page
+
+The root URL `/` displays links to the audit table and generated OpenAPI documentation.
+It also shows the application version, build time and Git commit id extracted from
+`build-info.properties` and `git.properties` at runtime. A sample `curl` command is
+provided for quickly testing the `/transform` endpoint.
+

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,15 @@
             <version>2.17.2</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
             <version>7.1.0</version>
@@ -57,6 +66,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -65,6 +81,18 @@
                 <configuration>
                     <release>${java.version}</release>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.15.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/example/transformer/HomeController.java
+++ b/src/main/java/com/example/transformer/HomeController.java
@@ -1,0 +1,32 @@
+package com.example.transformer;
+
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    private final BuildProperties buildProperties;
+    private final GitProperties gitProperties;
+
+    public HomeController(BuildProperties buildProperties, GitProperties gitProperties) {
+        this.buildProperties = buildProperties;
+        this.gitProperties = gitProperties;
+    }
+
+    @GetMapping(value = "/", produces = MediaType.TEXT_HTML_VALUE)
+    public String index(Model model) {
+        if (buildProperties != null) {
+            model.addAttribute("version", buildProperties.getVersion());
+            model.addAttribute("buildTime", buildProperties.getTime());
+        }
+        if (gitProperties != null) {
+            model.addAttribute("commitId", gitProperties.getShortCommitId());
+        }
+        return "index";
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head><title>XML to JSON Transformer</title></head>
+<body>
+<h2>XML to JSON Transformer</h2>
+<p>Version: <span th:text="${version}">n/a</span></p>
+<p>Build Time: <span th:text="${#dates.format(buildTime, 'yyyy-MM-dd HH:mm:ss')}">n/a</span></p>
+<p>Commit ID: <span th:text="${commitId}">n/a</span></p>
+<ul>
+<li><a href="/audit">Audit History</a></li>
+<li><a href="/v3/api-docs">OpenAPI Spec</a></li>
+<li><a href="/swagger-ui/index.html">Swagger UI</a></li>
+</ul>
+<h3>Sample Request</h3>
+<pre>curl -X POST -H "Content-Type: application/xml" --data-binary @example.xml http://localhost:8080/transform</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose build metadata and git commit on a new home page
- link to audit table and Swagger UI
- generate build and git info via Maven plugins
- document new home page in README

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ab31bcbfc832ebb6ca96019de43ed