### PR TITLE
Add logging via SLF4J

### DIFF
--- a/src/main/java/com/example/transformer/AuditController.java
+++ b/src/main/java/com/example/transformer/AuditController.java
@@ -6,11 +6,14 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 @Controller
 public class AuditController {
+    private static final Logger logger = LoggerFactory.getLogger(AuditController.class);
     private final AuditService service;
     private final AuditProperties props;
 
@@ -21,6 +24,7 @@ public class AuditController {
 
     @GetMapping(value = "/audit", produces = MediaType.TEXT_HTML_VALUE)
     public String list(@RequestParam(name = "page", defaultValue = "0") int page, Model model) {
+        logger.info("Audit list requested - page {}", page);
         model.addAttribute("entries", service.page(page, props.getPageSize()));
         model.addAttribute("page", page);
         model.addAttribute("pageSize", props.getPageSize());
@@ -29,8 +33,10 @@ public class AuditController {
 
     @GetMapping(value = "/audit/{id}", produces = MediaType.TEXT_HTML_VALUE)
     public String detail(@PathVariable("id") long id, Model model) throws IOException {
+        logger.info("Audit detail requested for id {}", id);
         AuditEntry entry = service.get(id);
         if (entry == null) {
+            logger.warn("Audit entry {} not found", id);
             return "auditDetail";
         }
         model.addAttribute("entry", entry);

--- a/src/main/java/com/example/transformer/AuditService.java
+++ b/src/main/java/com/example/transformer/AuditService.java
@@ -1,6 +1,8 @@
 package com.example.transformer;
 
 import org.springframework.stereotype.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -12,6 +14,7 @@ import java.util.stream.Collectors;
 
 @Service
 public class AuditService {
+    private static final Logger logger = LoggerFactory.getLogger(AuditService.class);
     private final Deque<AuditEntry> history = new ArrayDeque<>();
     private final int maxHistory;
     private final boolean compress;
@@ -34,8 +37,9 @@ public class AuditService {
                 }
                 history.addLast(entry);
             }
+            logger.info("Audit entry {} stored for {} - success: {}", entry.getId(), clientIp, success);
         } catch (IOException e) {
-            // ignore
+            logger.error("Failed to store audit entry for {}", clientIp, e);
         }
     }
 

--- a/src/main/java/com/example/transformer/HomeController.java
+++ b/src/main/java/com/example/transformer/HomeController.java
@@ -7,9 +7,13 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Controller
 public class HomeController {
+
+    private static final Logger logger = LoggerFactory.getLogger(HomeController.class);
 
     private final BuildProperties buildProperties;
     @Nullable
@@ -22,6 +26,7 @@ public class HomeController {
 
     @GetMapping(value = "/", produces = MediaType.TEXT_HTML_VALUE)
     public String index(Model model) {
+        logger.info("Home page requested");
         if (buildProperties != null) {
             model.addAttribute("version", buildProperties.getVersion());
             model.addAttribute("buildTime", buildProperties.getTime());

--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
@@ -18,6 +20,8 @@ import java.util.stream.Collectors;
 
 @Component
 public class XmlToJsonStreamer {
+
+    private static final Logger logger = LoggerFactory.getLogger(XmlToJsonStreamer.class);
 
     private final JsonFactory jsonFactory = new JsonFactory();
     private final MappingConfig config;
@@ -39,6 +43,7 @@ public class XmlToJsonStreamer {
     }
 
     public void transform(InputStream xmlInput, OutputStream jsonOutput) throws XMLStreamException, IOException {
+        logger.debug("Starting XML to JSON transformation");
         XMLInputFactory inFactory = XMLInputFactory.newFactory();
         XMLStreamReader reader = inFactory.createXMLStreamReader(xmlInput);
 
@@ -56,6 +61,7 @@ public class XmlToJsonStreamer {
         g.writeEndObject();
         g.flush();
         g.close();
+        logger.debug("XML to JSON transformation completed");
     }
 
     private String readElement(XMLStreamReader reader) throws XMLStreamException, IOException {


### PR DESCRIPTION
## Summary
- integrate SLF4J `Logger` into controllers and services
- log request handling and auditing events

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ac18a96b4832ea8404d6a850fce6d