### PR TITLE
Disable DTD parsing and add XXE regression test

### DIFF
--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -40,6 +40,8 @@ public class XmlToJsonStreamer {
 
     public void transform(InputStream xmlInput, OutputStream jsonOutput) throws XMLStreamException, IOException {
         XMLInputFactory inFactory = XMLInputFactory.newFactory();
+        inFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        inFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
         XMLStreamReader reader = inFactory.createXMLStreamReader(xmlInput);
 
         // advance to root element

--- a/src/test/java/com/example/transformer/XxeTest.java
+++ b/src/test/java/com/example/transformer/XxeTest.java
@@ -1,0 +1,23 @@
+package com.example.transformer;
+
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class XxeTest {
+
+    private final XmlToJsonStreamer streamer = new XmlToJsonStreamer(new MappingConfig());
+
+    @Test
+    public void externalEntityFails() {
+        String xml = "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><foo>&xxe;</foo>";
+        ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        assertThrows(XMLStreamException.class, () -> streamer.transform(in, out));
+    }
+}


### PR DESCRIPTION
## Summary
- secure XML parser against XXE by disabling DTDs and external entity processing
- add unit test verifying an XML containing external entity is rejected

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ac18d09ac832ea674e2e3aad86225