### PR TITLE
Refactor AuditService to use AuditStore

### DIFF
--- a/src/main/java/com/example/transformer/AuditConfiguration.java
+++ b/src/main/java/com/example/transformer/AuditConfiguration.java
@@ -12,4 +12,9 @@ public class AuditConfiguration {
         }
         return new InMemoryAuditStore(props.getHistorySize());
     }
+
+    @Bean
+    public AuditService auditService(AuditStore store, AuditProperties props) {
+        return new AuditService(props, store);
+    }
 }

--- a/src/test/java/com/example/transformer/AuditServiceTest.java
+++ b/src/test/java/com/example/transformer/AuditServiceTest.java
@@ -1,0 +1,23 @@
+package com.example.transformer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AuditServiceTest {
+
+    @Test
+    public void addAndRetrieve() throws Exception {
+        AuditProperties props = new AuditProperties();
+        props.setCompress(false);
+        InMemoryAuditStore store = new InMemoryAuditStore(10);
+        AuditService service = new AuditService(props, store);
+
+        service.add("127.0.0.1", 0L, 1L, true, "<a/>".getBytes(), "{}".getBytes());
+
+        assertEquals(1, service.page(0, 10).size());
+        AuditEntry entry = service.get(1);
+        assertNotNull(entry);
+        assertEquals("127.0.0.1", entry.getClientIp());
+    }
+}


### PR DESCRIPTION
## Summary
- refactor AuditService to depend on AuditStore
- wire AuditService via AuditConfiguration
- add simple AuditServiceTest

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad4b6eb78832e89cadbdb32a9b57f