### PR TITLE
Ensure XMLStreamReader is closed after transform

### DIFF
--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -47,22 +47,29 @@ public class XmlToJsonStreamer {
         XMLInputFactory inFactory = XMLInputFactory.newFactory();
         inFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         inFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        XMLStreamReader reader = inFactory.createXMLStreamReader(xmlInput);
+        XMLStreamReader reader = null;
+        try {
+            reader = inFactory.createXMLStreamReader(xmlInput);
 
-        // advance to root element
-        while (reader.hasNext() && reader.next() != XMLStreamConstants.START_ELEMENT) {
-            // skip until start element
+            // advance to root element
+            while (reader.hasNext() && reader.next() != XMLStreamConstants.START_ELEMENT) {
+                // skip until start element
+            }
+            String rootName = buildQName(reader.getPrefix(), reader.getLocalName());
+            String rootJson = readElement(reader);
+
+            JsonGenerator g = jsonFactory.createGenerator(jsonOutput);
+            g.writeStartObject();
+            g.writeFieldName(rootName);
+            g.writeRawValue(rootJson);
+            g.writeEndObject();
+            g.flush();
+            g.close();
+        } finally {
+            if (reader != null) {
+                reader.close();
+            }
         }
-        String rootName = buildQName(reader.getPrefix(), reader.getLocalName());
-        String rootJson = readElement(reader);
-
-        JsonGenerator g = jsonFactory.createGenerator(jsonOutput);
-        g.writeStartObject();
-        g.writeFieldName(rootName);
-        g.writeRawValue(rootJson);
-        g.writeEndObject();
-        g.flush();
-        g.close();
         logger.debug("XML to JSON transformation completed");
     }
 

--- a/src/test/java/com/example/transformer/XmlToJsonStreamerTest.java
+++ b/src/test/java/com/example/transformer/XmlToJsonStreamerTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class XmlToJsonStreamerTest {
 
@@ -31,6 +32,29 @@ public class XmlToJsonStreamerTest {
         String xml = "<p>Hello<b>x</b></p>";
         String expected = "{\"p\":{\"#text\":\"Hello\",\"b\":\"x\"}}";
         assertEquals(expected, transform(xml));
+    }
+
+    @Test
+    public void inputStreamClosed() throws Exception {
+        byte[] data = "<a/>".getBytes(StandardCharsets.UTF_8);
+        CloseTrackingInputStream in = new CloseTrackingInputStream(data);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        streamer.transform(in, out);
+        assertTrue(in.closed);
+    }
+
+    private static class CloseTrackingInputStream extends ByteArrayInputStream {
+        boolean closed = false;
+
+        CloseTrackingInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            closed = true;
+        }
     }
 
     private String transform(String xml) throws Exception {


### PR DESCRIPTION
## Summary
- close `XMLStreamReader` using try/finally block
- add unit test verifying input stream is closed when transform completes

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad4d157b0832ea079dc2fc42be78c