### PR TITLE
Switch audit store to JSON

### DIFF
--- a/src/main/java/com/example/transformer/AuditEntry.java
+++ b/src/main/java/com/example/transformer/AuditEntry.java
@@ -1,5 +1,8 @@
 package com.example.transformer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.io.*;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -16,8 +19,17 @@ public class AuditEntry implements java.io.Serializable {
     private final byte[] jsonData;
     private final boolean compressed;
 
-    public AuditEntry(long id, String clientIp, long requestTime, long responseTime, boolean success,
-                      long durationMs, byte[] xmlData, byte[] jsonData, boolean compressed) {
+    @JsonCreator
+    public AuditEntry(
+            @JsonProperty("id") long id,
+            @JsonProperty("clientIp") String clientIp,
+            @JsonProperty("requestTime") long requestTime,
+            @JsonProperty("responseTime") long responseTime,
+            @JsonProperty("success") boolean success,
+            @JsonProperty("durationMs") long durationMs,
+            @JsonProperty("xmlData") byte[] xmlData,
+            @JsonProperty("jsonData") byte[] jsonData,
+            @JsonProperty("compressed") boolean compressed) {
         this.id = id;
         this.clientIp = clientIp;
         this.requestTime = requestTime;

--- a/src/test/java/com/example/transformer/FileAuditStoreTest.java
+++ b/src/test/java/com/example/transformer/FileAuditStoreTest.java
@@ -1,0 +1,49 @@
+package com.example.transformer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FileAuditStoreTest {
+
+    @Test
+    public void writesAndReadsJson() throws Exception {
+        Path file = Files.createTempFile("audit", ".json");
+        Files.deleteIfExists(file);
+        FileAuditStore store = new FileAuditStore(file.toString(), 10);
+        AuditEntry e = new AuditEntry(1L, "ip", 1L, 2L, true, 1L, new byte[]{1}, new byte[]{2}, false);
+        store.save(e);
+
+        ObjectMapper mapper = new ObjectMapper();
+        List<AuditEntry> list = mapper.readValue(file.toFile(), new TypeReference<List<AuditEntry>>() {});
+        assertEquals(1, list.size());
+        assertEquals(1L, list.get(0).getId());
+
+        Files.deleteIfExists(file);
+    }
+
+    @Test
+    public void migratesFromLegacyFormat() throws Exception {
+        Path file = Files.createTempFile("audit", ".ser");
+        AuditEntry e = new AuditEntry(1L, "ip", 1L, 2L, true, 1L, new byte[]{1}, new byte[]{2}, false);
+        try (ObjectOutputStream out = new ObjectOutputStream(Files.newOutputStream(file))) {
+            out.writeObject(List.of(e));
+        }
+        FileAuditStore store = new FileAuditStore(file.toString(), 10);
+        assertEquals(1, store.page(0, 10).size());
+
+        ObjectMapper mapper = new ObjectMapper();
+        List<AuditEntry> list = mapper.readValue(file.toFile(), new TypeReference<List<AuditEntry>>() {});
+        assertEquals(1, list.size());
+        assertEquals(1L, list.get(0).getId());
+
+        Files.deleteIfExists(file);
+    }
+}


### PR DESCRIPTION
## Summary
- save audit history in JSON instead of Java serialization
- auto-migrate existing `.ser` files to JSON
- annotate `AuditEntry` for Jackson use
- add unit tests for `FileAuditStore`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad4de39a4832e898363afd12c09db