### PR TITLE
Handle missing audit entry with 404

### DIFF
--- a/src/main/java/com/example/transformer/AuditController.java
+++ b/src/main/java/com/example/transformer/AuditController.java
@@ -1,6 +1,7 @@
 package com.example.transformer;
 
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,12 +33,12 @@ public class AuditController {
     }
 
     @GetMapping(value = "/audit/{id}", produces = MediaType.TEXT_HTML_VALUE)
-    public String detail(@PathVariable("id") long id, Model model) throws IOException {
+    public Object detail(@PathVariable("id") long id, Model model) throws IOException {
         logger.info("Audit detail requested for id {}", id);
         AuditEntry entry = service.get(id);
         if (entry == null) {
             logger.warn("Audit entry {} not found", id);
-            return "auditDetail";
+            return ResponseEntity.notFound().build();
         }
         model.addAttribute("entry", entry);
         return "auditDetail";

--- a/src/test/java/com/example/transformer/AuditControllerMockMvcTest.java
+++ b/src/test/java/com/example/transformer/AuditControllerMockMvcTest.java
@@ -1,0 +1,24 @@
+package com.example.transformer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuditControllerMockMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void detailNotFound() throws Exception {
+        mockMvc.perform(get("/audit/1"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- return `ResponseEntity.notFound()` when audit entry is missing
- add `AuditControllerMockMvcTest` to verify 404 response

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad4f0830c832eab7581ded195cdbb