### PR TITLE
Fix AuditService bean creation

### DIFF
--- a/src/main/java/com/example/transformer/AuditConfiguration.java
+++ b/src/main/java/com/example/transformer/AuditConfiguration.java
@@ -14,7 +14,7 @@ public class AuditConfiguration {
     }
 
     @Bean
-    public AuditService auditService(AuditStore store, AuditProperties props) {
-        return new AuditService(props, store);
+    public AuditService auditService(AuditProperties props) {
+        return new AuditService(props);
     }
 }

--- a/src/test/java/com/example/transformer/AuditServiceTest.java
+++ b/src/test/java/com/example/transformer/AuditServiceTest.java
@@ -10,8 +10,7 @@ public class AuditServiceTest {
     public void addAndRetrieve() throws Exception {
         AuditProperties props = new AuditProperties();
         props.setCompress(false);
-        InMemoryAuditStore store = new InMemoryAuditStore(10);
-        AuditService service = new AuditService(props, store);
+        AuditService service = new AuditService(props);
 
         service.add("127.0.0.1", 0L, 1L, true, "<a/>".getBytes(), "{}".getBytes());
 


### PR DESCRIPTION
## Summary
- adjust `AuditConfiguration` to use `AuditService` constructor that only takes `AuditProperties`
- update `AuditServiceTest` accordingly

## Testing
- `mvn clean install` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad7dc1e48832e963b30135b6e672f