### PR TITLE
Fix test compilation

### DIFF
--- a/src/test/java/com/example/transformer/XmlToJsonStreamerTest.java
+++ b/src/test/java/com/example/transformer/XmlToJsonStreamerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
## Summary
- add missing IOException import for XmlToJsonStreamerTest

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ada46a464832ea6394753b6272550