### PR TITLE
Fix build after audit features merged

### DIFF
--- a/src/main/java/com/example/transformer/AuditEntry.java
+++ b/src/main/java/com/example/transformer/AuditEntry.java
@@ -2,6 +2,7 @@ package com.example.transformer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 
 import java.io.*;
 import java.util.zip.GZIPInputStream;
@@ -15,7 +16,9 @@ public class AuditEntry implements java.io.Serializable {
     private final long responseTime;
     private final boolean success;
     private final long durationMs;
+    @JsonAlias("xml")
     private final byte[] xmlData;
+    @JsonAlias("json")
     private final byte[] jsonData;
     private final boolean compressed;
 
@@ -27,8 +30,8 @@ public class AuditEntry implements java.io.Serializable {
             @JsonProperty("responseTime") long responseTime,
             @JsonProperty("success") boolean success,
             @JsonProperty("durationMs") long durationMs,
-            @JsonProperty("xmlData") byte[] xmlData,
-            @JsonProperty("jsonData") byte[] jsonData,
+            @JsonProperty(value = "xmlData", aliases = {"xml"}) byte[] xmlData,
+            @JsonProperty(value = "jsonData", aliases = {"json"}) byte[] jsonData,
             @JsonProperty("compressed") boolean compressed) {
         this.id = id;
         this.clientIp = clientIp;

--- a/src/main/java/com/example/transformer/TransformController.java
+++ b/src/main/java/com/example/transformer/TransformController.java
@@ -29,14 +29,14 @@ public class TransformController {
 
     @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE},
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<StreamingResponseBody> transform(@RequestBody InputStream xmlStream,
+    public ResponseEntity<StreamingResponseBody> transform(@RequestBody byte[] xml,
                                                           HttpServletRequest request) {
         long start = System.currentTimeMillis();
         String clientIp = request.getRemoteAddr();
 
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         try {
-            streamer.transform(xmlStream, buffer);
+            streamer.transform(new java.io.ByteArrayInputStream(xml), buffer);
             long end = System.currentTimeMillis();
             auditService.add(clientIp, start, end, true, new byte[0], new byte[0]);
             byte[] data = buffer.toByteArray();


### PR DESCRIPTION
## Summary
- ensure AuditEntry JSON backward compatibility with alias annotations
- disable unicode escaping in XmlToJsonStreamer and rework repeated sibling handling
- close streams after processing and fix controller to accept byte[]

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683add300ce8832e8936ffc7781d477d