### PR TITLE
Fix thread safety in AuditService

### DIFF
--- a/src/main/java/com/example/transformer/AuditService.java
+++ b/src/main/java/com/example/transformer/AuditService.java
@@ -31,10 +31,12 @@ public class AuditService {
             byte[] j = compress ? AuditEntry.compress(json) : json;
             AuditEntry entry = new AuditEntry(counter.incrementAndGet(), clientIp, start, end,
                     success, end - start, x, j, compress);
-            if (history.size() >= maxHistory) {
-                history.removeFirst();
+            synchronized (history) {
+                if (history.size() >= maxHistory) {
+                    history.removeFirst();
+                }
+                history.addLast(entry);
             }
-            history.addLast(entry);
             logger.info("Audit entry {} stored for {} - success: {}", entry.getId(), clientIp, success);
         } catch (IOException e) {
             logger.error("Failed to store audit entry for {}", clientIp, e);


### PR DESCRIPTION
## Summary
- ensure AuditService.add removes and appends entries atomically to avoid race conditions

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ae82c1cc8832e978afed9f2ed8626