### PR TITLE
Fix JSON streaming and test isolation

### DIFF
--- a/src/test/java/com/example/transformer/AuditControllerMockMvcTest.java
+++ b/src/test/java/com/example/transformer/AuditControllerMockMvcTest.java
@@ -1,6 +1,7 @@
 package com.example.transformer;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,6 +16,14 @@ public class AuditControllerMockMvcTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private AuditService auditService;
+
+    @BeforeEach
+    public void setup() {
+        auditService.clear();
+    }
 
     @Test
     public void detailNotFound() throws Exception {


### PR DESCRIPTION
## Summary
- avoid unnecessary json factory feature configuration at build time
- configure generator per stream and reuse generator for child fragments to reduce memory
- add AuditService.clear for tests and clear history before mock MVC test

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_683ae82c1cc8832e978afed9f2ed8626