### PR TITLE
Fix JSON output formatting

### DIFF
--- a/src/main/java/com/example/transformer/CompactPrettyPrinter.java
+++ b/src/main/java/com/example/transformer/CompactPrettyPrinter.java
@@ -1,0 +1,29 @@
+package com.example.transformer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
+import java.io.IOException;
+
+/**
+ * Pretty printer that avoids spaces and root separators.
+ */
+public class CompactPrettyPrinter extends MinimalPrettyPrinter {
+    public CompactPrettyPrinter() {
+        this._rootValueSeparator = "";
+    }
+
+    @Override
+    public void writeObjectFieldValueSeparator(JsonGenerator g) throws IOException {
+        g.writeRaw(':');
+    }
+
+    @Override
+    public void writeArrayValueSeparator(JsonGenerator g) throws IOException {
+        g.writeRaw(',');
+    }
+
+    @Override
+    public void writeRootValueSeparator(JsonGenerator g) throws IOException {
+        // no root value separator
+    }
+}

--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -2,6 +2,8 @@ package com.example.transformer;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.example.transformer.CompactPrettyPrinter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
@@ -29,7 +31,9 @@ public class XmlToJsonStreamer {
     @Autowired
     public XmlToJsonStreamer(MappingConfig config) {
         this.config = config;
-        this.jsonFactory = JsonFactory.builder().build();
+        this.jsonFactory = JsonFactory.builder()
+                .configure(JsonWriteFeature.ESCAPE_NON_ASCII, false)
+                .build();
     }
 
     public XmlToJsonStreamer() {
@@ -57,6 +61,7 @@ public class XmlToJsonStreamer {
         String rootName = buildQName(reader.getPrefix(), reader.getLocalName());
         JsonGenerator g = jsonFactory.createGenerator(jsonOutput);
         g.configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+        g.setPrettyPrinter(new CompactPrettyPrinter());
         g.writeStartObject();
         g.writeFieldName(rootName);
         readElement(reader, g);
@@ -96,6 +101,7 @@ public class XmlToJsonStreamer {
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         JsonGenerator tmp = jsonFactory.createGenerator(buf);
         tmp.configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+        tmp.setPrettyPrinter(new CompactPrettyPrinter());
         while (reader.hasNext()) {
             int event = reader.next();
             if (event == XMLStreamConstants.START_ELEMENT) {


### PR DESCRIPTION
## Summary
- ensure JsonFactory never escapes non-ASCII output
- add `CompactPrettyPrinter` to suppress whitespace
- use the printer for all JsonGenerators

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683af398cae0832ea220786ab7ff7853