### PR TITLE
Fix emoji escaping in audit log and transformer

### DIFF
--- a/src/main/java/com/example/transformer/FileAuditStore.java
+++ b/src/main/java/com/example/transformer/FileAuditStore.java
@@ -1,5 +1,7 @@
 package com.example.transformer;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -19,11 +21,14 @@ public class FileAuditStore implements AuditStore {
     private final Path file;
     private final Deque<AuditEntry> history = new ConcurrentLinkedDeque<>();
     private final int maxHistory;
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper;
 
     public FileAuditStore(String filePath, int maxHistory) {
         this.file = Paths.get(filePath);
         this.maxHistory = maxHistory;
+        this.mapper = new ObjectMapper();
+        this.mapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+        this.mapper.getFactory().configure(JsonWriteFeature.ESCAPE_NON_ASCII, false);
         load();
     }
 

--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -3,6 +3,7 @@ package com.example.transformer;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.example.transformer.CompactPrettyPrinter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,7 @@ public class XmlToJsonStreamer {
         this.config = config;
         this.jsonFactory = JsonFactory.builder()
                 .configure(JsonWriteFeature.ESCAPE_NON_ASCII, false)
+                .configure(Feature.ESCAPE_NON_ASCII, false)
                 .build();
     }
 


### PR DESCRIPTION
## Summary
- ensure the JsonFactory used by `XmlToJsonStreamer` disables non-ASCII escaping
- disable non-ASCII escaping in `FileAuditStore`'s `ObjectMapper`

## Testing
- `mvn -q -Dtest=UnicodeTest test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683af6c05fe0832e8eda6f6e2022ae31