### PR TITLE
Fix streaming memory use and emoji escaping

### DIFF
--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -32,7 +32,7 @@ public class XmlToJsonStreamer {
     public XmlToJsonStreamer(MappingConfig config) {
         this.config = config;
         this.jsonFactory = JsonFactory.builder()
-                .configure(JsonWriteFeature.ESCAPE_NON_ASCII, false)
+                .disable(JsonWriteFeature.ESCAPE_NON_ASCII)
                 .build();
     }
 
@@ -74,15 +74,12 @@ public class XmlToJsonStreamer {
     }
 
     private static class ChildState {
-        final StringBuilder fragments = new StringBuilder();
+        final List<String> fragments = new ArrayList<>();
         String lastFragment;
         int count = 0;
 
         void add(String fragment) {
-            if (count > 0) {
-                fragments.append(',');
-            }
-            fragments.append(fragment);
+            fragments.add(fragment);
             lastFragment = fragment;
             count++;
         }
@@ -138,9 +135,13 @@ public class XmlToJsonStreamer {
                 if (!config.isArraysForRepeatedSiblings()) {
                     out.writeRawValue(state.lastFragment);
                 } else if (state.count == 1) {
-                    out.writeRawValue(state.fragments.toString());
+                    out.writeRawValue(state.fragments.get(0));
                 } else {
-                    out.writeRawValue("[" + state.fragments.toString() + "]");
+                    out.writeStartArray();
+                    for (String fragment : state.fragments) {
+                        out.writeRawValue(fragment);
+                    }
+                    out.writeEndArray();
                 }
             }
             out.writeEndObject();


### PR DESCRIPTION
## Summary
- stream JSON arrays element-by-element to avoid large buffers
- disable ASCII escaping using JsonFactory builder

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b0472fcb4832e8a5e74930eecfb22