### PR TITLE
Fix Unicode escaping

### DIFF
--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -2,6 +2,8 @@ package com.example.transformer;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.example.transformer.CompactPrettyPrinter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +27,34 @@ public class XmlToJsonStreamer {
 
     private static final Logger logger = LoggerFactory.getLogger(XmlToJsonStreamer.class);
 
+    /**
+     * {@link CharacterEscapes} implementation that suppresses unnecessary
+     * escaping so all Unicode code points are written as raw UTF-8.
+     */
+    public static final class NoAsciiEscapes extends CharacterEscapes {
+        private static final long serialVersionUID = 1L;
+
+        private static final int[] ESC = CharacterEscapes.standardAsciiEscapesForJSON();
+        static {
+            for (int i = 32; i < ESC.length; i++) {
+                if (i != '"' && i != '\\') {
+                    ESC[i] = CharacterEscapes.ESCAPE_NONE;
+                }
+            }
+        }
+
+        @Override
+        public int[] getEscapeCodesForAscii() {
+            return ESC;
+        }
+
+        /** Never escape any non-ASCII code point */
+        @Override
+        public SerializedString getEscapeSequence(int ch) {
+            return null;
+        }
+    }
+
     private final JsonFactory jsonFactory;
     private final MappingConfig config;
 
@@ -34,8 +64,6 @@ public class XmlToJsonStreamer {
         JsonFactory f = JsonFactory.builder()
                 .disable(JsonWriteFeature.ESCAPE_NON_ASCII)
                 .build();
-        // also ensure generator-level feature is disabled
-        f.configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
         this.jsonFactory = f;
     }
 
@@ -63,7 +91,7 @@ public class XmlToJsonStreamer {
         }
         String rootName = buildQName(reader.getPrefix(), reader.getLocalName());
         JsonGenerator g = jsonFactory.createGenerator(jsonOutput);
-        g.configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+        g.setCharacterEscapes(new NoAsciiEscapes());
         g.setPrettyPrinter(new CompactPrettyPrinter());
         g.writeStartObject();
         g.writeFieldName(rootName);
@@ -100,7 +128,7 @@ public class XmlToJsonStreamer {
 
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         JsonGenerator tmp = jsonFactory.createGenerator(buf);
-        tmp.configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+        tmp.setCharacterEscapes(new NoAsciiEscapes());
         tmp.setPrettyPrinter(new CompactPrettyPrinter());
         while (reader.hasNext()) {
             int event = reader.next();


### PR DESCRIPTION
## Summary
- create custom CharacterEscapes so Jackson never escapes non-ASCII codepoints
- wire new escapes into JsonGenerators
- remove redundant escape configuration

## Testing
- `mvn clean test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b0f8d455c832ea60992a5d310d5dd