### PR TITLE
Enhance XmlToJsonStreamer utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,20 @@ The tests also cover unicode handling, repeated siblings and ignoring XML commen
 
 ### Configuration
 
-`MappingConfig` exposes the following properties which can be overridden via `application.yml`:
+`MappingConfig` exposes the following properties which can be overridden via `application.yml` or configured programmatically using the `XmlToJsonStreamer.Builder`:
 
 ```
 mapping.attribute-prefix=@
 mapping.text-field=#text
 mapping.arrays-for-repeated-siblings=true
+mapping.wrap-root=true
+mapping.pretty-print=false
+mapping.preserve-namespaces=true
+mapping.escape-non-ascii=false
 ```
 
 These allow customizing how attributes, text content and repeated elements are represented in the produced JSON.
+Additional options control root wrapping, pretty printing, namespace handling and escaping of non ASCII characters.
 
 ### Audit History
 

--- a/src/main/java/com/example/transformer/MappingConfig.java
+++ b/src/main/java/com/example/transformer/MappingConfig.java
@@ -6,6 +6,10 @@ public class MappingConfig {
     private String attributePrefix = "@";
     private String textField = "#text";
     private boolean arraysForRepeatedSiblings = true;
+    private boolean wrapRoot = true;
+    private boolean prettyPrint = false;
+    private boolean preserveNamespaces = true;
+    private boolean escapeNonAscii = false;
 
     public String getAttributePrefix() {
         return attributePrefix;
@@ -29,5 +33,37 @@ public class MappingConfig {
 
     public void setArraysForRepeatedSiblings(boolean arraysForRepeatedSiblings) {
         this.arraysForRepeatedSiblings = arraysForRepeatedSiblings;
+    }
+
+    public boolean isWrapRoot() {
+        return wrapRoot;
+    }
+
+    public void setWrapRoot(boolean wrapRoot) {
+        this.wrapRoot = wrapRoot;
+    }
+
+    public boolean isPrettyPrint() {
+        return prettyPrint;
+    }
+
+    public void setPrettyPrint(boolean prettyPrint) {
+        this.prettyPrint = prettyPrint;
+    }
+
+    public boolean isPreserveNamespaces() {
+        return preserveNamespaces;
+    }
+
+    public void setPreserveNamespaces(boolean preserveNamespaces) {
+        this.preserveNamespaces = preserveNamespaces;
+    }
+
+    public boolean isEscapeNonAscii() {
+        return escapeNonAscii;
+    }
+
+    public void setEscapeNonAscii(boolean escapeNonAscii) {
+        this.escapeNonAscii = escapeNonAscii;
     }
 }

--- a/src/main/java/com/example/transformer/TransformController.java
+++ b/src/main/java/com/example/transformer/TransformController.java
@@ -47,7 +47,11 @@ public class TransformController {
         } catch (XMLStreamException | IOException e) {
             long end = System.currentTimeMillis();
             auditService.add(clientIp, start, end, false, new byte[0], new byte[0]);
-            return ResponseEntity.badRequest().build();
+            byte[] msg = e.getMessage() == null ? new byte[0] : e.getMessage().getBytes();
+            StreamingResponseBody body = out -> out.write(msg);
+            return ResponseEntity.badRequest()
+                    .contentType(MediaType.TEXT_PLAIN)
+                    .body(body);
         }
     }
 }

--- a/src/main/java/com/example/transformer/TransformerConfiguration.java
+++ b/src/main/java/com/example/transformer/TransformerConfiguration.java
@@ -1,0 +1,12 @@
+package com.example.transformer;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TransformerConfiguration {
+    @Bean
+    public XmlToJsonStreamer xmlToJsonStreamer(MappingConfig config) throws java.io.IOException {
+        return new XmlToJsonStreamer(config);
+    }
+}

--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,40 +19,70 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-@Component
 public class XmlToJsonStreamer {
 
     private static final Logger logger = LoggerFactory.getLogger(XmlToJsonStreamer.class);
 
     private final JsonFactory jsonFactory;
+    private final XMLInputFactory xmlFactory;
     private final MappingConfig config;
 
     /* reusable scratch objects ― created once */
     private final ByteArrayOutputStream scratch = new ByteArrayOutputStream(64);
     private final JsonGenerator scratchGen;
 
-    @Autowired
     public XmlToJsonStreamer(MappingConfig config) throws IOException {
-        this.config = config;
-        JsonFactory f = JsonFactory.builder()
-                .configure(JsonWriteFeature.ESCAPE_NON_ASCII, false)
+        this(JsonFactory.builder()
+                .configure(JsonWriteFeature.ESCAPE_NON_ASCII, config.isEscapeNonAscii())
                 .configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8, true)
-                .build();
-        this.jsonFactory = f;
-
-        /* create the scratch generator only once */
-        this.scratchGen = jsonFactory.createGenerator(scratch);
-        this.scratchGen.configure(
-                JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
-        this.scratchGen.setPrettyPrinter(new CompactPrettyPrinter());
+                .build(),
+             XMLInputFactory.newFactory(),
+             config);
     }
 
     public XmlToJsonStreamer() throws IOException {
         this(new MappingConfig());
     }
 
+    private XmlToJsonStreamer(JsonFactory jsonFactory, XMLInputFactory xmlFactory, MappingConfig config) throws IOException {
+        this.config = config;
+        this.jsonFactory = jsonFactory;
+        this.xmlFactory = xmlFactory;
+
+        this.xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        this.xmlFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+
+        /* create the scratch generator only once */
+        this.scratchGen = jsonFactory.createGenerator(scratch);
+        this.scratchGen.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
+        this.scratchGen.setPrettyPrinter(new CompactPrettyPrinter());
+    }
+
+    public static class Builder {
+        private JsonFactory jsonFactory;
+        private XMLInputFactory xmlFactory;
+        private MappingConfig config = new MappingConfig();
+
+        public Builder jsonFactory(JsonFactory f) { this.jsonFactory = f; return this; }
+        public Builder xmlFactory(XMLInputFactory f) { this.xmlFactory = f; return this; }
+        public Builder config(MappingConfig c) { this.config = c; return this; }
+
+        public XmlToJsonStreamer build() throws IOException {
+            if (jsonFactory == null) {
+                jsonFactory = JsonFactory.builder()
+                        .configure(JsonWriteFeature.ESCAPE_NON_ASCII, config.isEscapeNonAscii())
+                        .configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8, true)
+                        .build();
+            }
+            if (xmlFactory == null) {
+                xmlFactory = XMLInputFactory.newFactory();
+            }
+            return new XmlToJsonStreamer(jsonFactory, xmlFactory, config);
+        }
+    }
+
     private String buildQName(String prefix, String local) {
-        if (prefix == null || prefix.isEmpty()) {
+        if (!config.isPreserveNamespaces() || prefix == null || prefix.isEmpty()) {
             return local;
         }
         return prefix + ":" + local;
@@ -62,10 +90,7 @@ public class XmlToJsonStreamer {
 
     public void transform(InputStream xmlInput, OutputStream jsonOutput) throws XMLStreamException, IOException {
         logger.debug("Starting XML to JSON transformation");
-        XMLInputFactory inFactory = XMLInputFactory.newFactory();
-        inFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-        inFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        XMLStreamReader reader = inFactory.createXMLStreamReader(xmlInput);
+        XMLStreamReader reader = xmlFactory.createXMLStreamReader(xmlInput);
 
         // advance to root element
         while (reader.hasNext() && reader.next() != XMLStreamConstants.START_ELEMENT) {
@@ -75,13 +100,22 @@ public class XmlToJsonStreamer {
         JsonGenerator g = jsonFactory.createGenerator(jsonOutput);
 
         g.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
-        g.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), false);
+        g.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), config.isEscapeNonAscii());
 
-        g.setPrettyPrinter(new CompactPrettyPrinter());
-        g.writeStartObject();
-        g.writeFieldName(rootName);
-        readElement(reader, g);
-        g.writeEndObject();
+        if (config.isPrettyPrint()) {
+            g.useDefaultPrettyPrinter();
+        } else {
+            g.setPrettyPrinter(new CompactPrettyPrinter());
+        }
+
+        if (config.isWrapRoot()) {
+            g.writeStartObject();
+            g.writeFieldName(rootName);
+            readElement(reader, g);
+            g.writeEndObject();
+        } else {
+            readElement(reader, g);
+        }
         g.flush();
         g.close();
         reader.close();
@@ -161,5 +195,38 @@ public class XmlToJsonStreamer {
             }
             out.writeEndObject();
         }
+    }
+
+    public void transform(Reader xmlReader, Writer jsonWriter) throws XMLStreamException, IOException {
+        logger.debug("Starting XML to JSON transformation");
+        XMLStreamReader reader = xmlFactory.createXMLStreamReader(xmlReader);
+
+        while (reader.hasNext() && reader.next() != XMLStreamConstants.START_ELEMENT) {
+        }
+        String rootName = buildQName(reader.getPrefix(), reader.getLocalName());
+        JsonGenerator g = jsonFactory.createGenerator(jsonWriter);
+
+        g.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
+        g.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), config.isEscapeNonAscii());
+
+        if (config.isPrettyPrint()) {
+            g.useDefaultPrettyPrinter();
+        } else {
+            g.setPrettyPrinter(new CompactPrettyPrinter());
+        }
+
+        if (config.isWrapRoot()) {
+            g.writeStartObject();
+            g.writeFieldName(rootName);
+            readElement(reader, g);
+            g.writeEndObject();
+        } else {
+            readElement(reader, g);
+        }
+        g.flush();
+        g.close();
+        reader.close();
+        xmlReader.close();
+        logger.debug("XML to JSON transformation completed");
     }
 }

--- a/src/test/java/com/example/transformer/RootWrapTest.java
+++ b/src/test/java/com/example/transformer/RootWrapTest.java
@@ -1,0 +1,36 @@
+package com.example.transformer;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RootWrapTest {
+
+    @Test
+    public void unwrapRoot() throws Exception {
+        MappingConfig cfg = new MappingConfig();
+        cfg.setWrapRoot(false);
+        XmlToJsonStreamer streamer = new XmlToJsonStreamer(cfg);
+        String xml = "<a>v</a>";
+        ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        streamer.transform(in, out);
+        assertEquals("\"v\"", out.toString());
+    }
+
+    @Test
+    public void readerWriter() throws Exception {
+        MappingConfig cfg = new MappingConfig();
+        cfg.setPrettyPrint(true);
+        XmlToJsonStreamer streamer = new XmlToJsonStreamer(cfg);
+        java.io.StringReader reader = new java.io.StringReader("<x><y>z</y></x>");
+        java.io.StringWriter writer = new java.io.StringWriter();
+        streamer.transform(reader, writer);
+        String expected = "{\n  \"x\" : {\n    \"y\" : \"z\"\n  }\n}";
+        assertEquals(expected, writer.toString().trim());
+    }
+}


### PR DESCRIPTION
## Summary
- expose more mapping configuration options
- add builder pattern for XmlToJsonStreamer
- allow unwrapped root and pretty printing
- support Reader/Writer APIs
- provide Spring configuration for streamer bean
- improve error responses
- document new settings
- add RootWrapTest

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b30a14e24832e959d1973bb936cb8