### PR TITLE
Refactor XmlToJsonStreamer for library use

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The tests also cover unicode handling, repeated siblings and ignoring XML commen
 
 ### Configuration
 
-`MappingConfig` exposes the following properties which can be overridden via `application.yml` or configured programmatically using the `XmlToJsonStreamer.Builder`:
+`MappingConfig` exposes the following properties which can be overridden via `application.yml` or configured programmatically using the fluent `XmlToJsonStreamer.builder()` API:
 
 ```
 mapping.attribute-prefix=@

--- a/src/main/java/com/example/transformer/MappingConfig.java
+++ b/src/main/java/com/example/transformer/MappingConfig.java
@@ -1,7 +1,6 @@
 package com.example.transformer;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-@ConfigurationProperties(prefix = "mapping")
+
 public class MappingConfig {
     private String attributePrefix = "@";
     private String textField = "#text";

--- a/src/main/java/com/example/transformer/TransformerConfiguration.java
+++ b/src/main/java/com/example/transformer/TransformerConfiguration.java
@@ -1,12 +1,19 @@
 package com.example.transformer;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class TransformerConfiguration {
     @Bean
+    @ConfigurationProperties(prefix = "mapping")
+    public MappingConfig mappingConfig() {
+        return new MappingConfig();
+    }
+
+    @Bean
     public XmlToJsonStreamer xmlToJsonStreamer(MappingConfig config) throws java.io.IOException {
-        return new XmlToJsonStreamer(config);
+        return XmlToJsonStreamer.builder().mappingConfig(config).build();
     }
 }

--- a/src/main/java/com/example/transformer/XmlJsonTransformerApplication.java
+++ b/src/main/java/com/example/transformer/XmlJsonTransformerApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties({MappingConfig.class, AuditProperties.class})
+@EnableConfigurationProperties({AuditProperties.class})
 public class XmlJsonTransformerApplication {
     public static void main(String[] args) {
         SpringApplication.run(XmlJsonTransformerApplication.class, args);

--- a/src/test/java/com/example/transformer/CommentsAndPITest.java
+++ b/src/test/java/com/example/transformer/CommentsAndPITest.java
@@ -11,7 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommentsAndPITest {
 
-    private final XmlToJsonStreamer streamer = new XmlToJsonStreamer(new MappingConfig());
+    private final XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+            .mappingConfig(new MappingConfig())
+            .build();
 
     public CommentsAndPITest() throws IOException {
     }

--- a/src/test/java/com/example/transformer/LargeStreamTest.java
+++ b/src/test/java/com/example/transformer/LargeStreamTest.java
@@ -52,7 +52,9 @@ public class LargeStreamTest {
 
     @Test
     public void streamerLargeDocument() throws Exception {
-        XmlToJsonStreamer streamer = new XmlToJsonStreamer(new MappingConfig());
+        XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+                .mappingConfig(new MappingConfig())
+                .build();
 
         StringBuilder sb = new StringBuilder();
         sb.append("<items>");

--- a/src/test/java/com/example/transformer/NamespaceTest.java
+++ b/src/test/java/com/example/transformer/NamespaceTest.java
@@ -11,7 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NamespaceTest {
 
-    private final XmlToJsonStreamer streamer = new XmlToJsonStreamer(new MappingConfig());
+    private final XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+            .mappingConfig(new MappingConfig())
+            .build();
 
     public NamespaceTest() throws IOException {
     }

--- a/src/test/java/com/example/transformer/RepeatedSiblingsDisabledTest.java
+++ b/src/test/java/com/example/transformer/RepeatedSiblingsDisabledTest.java
@@ -14,7 +14,9 @@ public class RepeatedSiblingsDisabledTest {
     public void noArrayUsesLastValue() throws Exception {
         MappingConfig cfg = new MappingConfig();
         cfg.setArraysForRepeatedSiblings(false);
-        XmlToJsonStreamer streamer = new XmlToJsonStreamer(cfg);
+        XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+                .mappingConfig(cfg)
+                .build();
         String xml = "<items><item>x</item><item>y</item></items>";
         ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/src/test/java/com/example/transformer/RepeatedSiblingsTest.java
+++ b/src/test/java/com/example/transformer/RepeatedSiblingsTest.java
@@ -11,7 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RepeatedSiblingsTest {
 
-    private final XmlToJsonStreamer streamer = new XmlToJsonStreamer(new MappingConfig());
+    private final XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+            .mappingConfig(new MappingConfig())
+            .build();
 
     public RepeatedSiblingsTest() throws IOException {
     }

--- a/src/test/java/com/example/transformer/RootWrapTest.java
+++ b/src/test/java/com/example/transformer/RootWrapTest.java
@@ -14,7 +14,9 @@ public class RootWrapTest {
     public void unwrapRoot() throws Exception {
         MappingConfig cfg = new MappingConfig();
         cfg.setWrapRoot(false);
-        XmlToJsonStreamer streamer = new XmlToJsonStreamer(cfg);
+        XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+                .mappingConfig(cfg)
+                .build();
         String xml = "<a>v</a>";
         ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -26,7 +28,9 @@ public class RootWrapTest {
     public void readerWriter() throws Exception {
         MappingConfig cfg = new MappingConfig();
         cfg.setPrettyPrint(true);
-        XmlToJsonStreamer streamer = new XmlToJsonStreamer(cfg);
+        XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+                .mappingConfig(cfg)
+                .build();
         java.io.StringReader reader = new java.io.StringReader("<x><y>z</y></x>");
         java.io.StringWriter writer = new java.io.StringWriter();
         streamer.transform(reader, writer);

--- a/src/test/java/com/example/transformer/UnicodeTest.java
+++ b/src/test/java/com/example/transformer/UnicodeTest.java
@@ -11,7 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UnicodeTest {
 
-    private final XmlToJsonStreamer streamer = new XmlToJsonStreamer(new MappingConfig());
+    private final XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+            .mappingConfig(new MappingConfig())
+            .build();
 
     public UnicodeTest() throws IOException {
     }

--- a/src/test/java/com/example/transformer/XmlToJsonStreamerTest.java
+++ b/src/test/java/com/example/transformer/XmlToJsonStreamerTest.java
@@ -12,7 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class XmlToJsonStreamerTest {
 
-    private final XmlToJsonStreamer streamer = new XmlToJsonStreamer(new MappingConfig());
+    private final XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+            .mappingConfig(new MappingConfig())
+            .build();
 
     public XmlToJsonStreamerTest() throws IOException {
     }

--- a/src/test/java/com/example/transformer/XxeTest.java
+++ b/src/test/java/com/example/transformer/XxeTest.java
@@ -12,7 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class XxeTest {
 
-    private final XmlToJsonStreamer streamer = new XmlToJsonStreamer(new MappingConfig());
+    private final XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+            .mappingConfig(new MappingConfig())
+            .build();
 
     public XxeTest() throws IOException {
     }


### PR DESCRIPTION
## Summary
- decouple `XmlToJsonStreamer` from Spring
- introduce fluent `builder()` API and rename builder setters
- expose `MappingConfig` as a plain POJO
- configure Spring beans using new builder
- update tests and docs for builder usage

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683be65c84e0832ea76f1be686d21e8d