### PR TITLE
Add builder options for root wrapping and pretty printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ mapping.escape-non-ascii=false
 ```
 
 These allow customizing how attributes, text content and repeated elements are represented in the produced JSON.
-Additional options control root wrapping, pretty printing, namespace handling and escaping of non ASCII characters.
+Root wrapping can be disabled by setting `mapping.wrap-root=false` or using
+`XmlToJsonStreamer.builder().wrapRootElement(false)` so that the children of the
+XML root element become the top level JSON fields. Human readable formatting can
+be enabled via `mapping.pretty-print=true` or `XmlToJsonStreamer.builder().prettyPrint(true)`.
+Additional options control namespace handling and escaping of non ASCII characters.
 
 ### Audit History
 

--- a/src/main/java/com/example/transformer/MappingConfig.java
+++ b/src/main/java/com/example/transformer/MappingConfig.java
@@ -5,6 +5,12 @@ public class MappingConfig {
     private String attributePrefix = "@";
     private String textField = "#text";
     private boolean arraysForRepeatedSiblings = true;
+    /**
+     * Whether to wrap the root element name in the produced JSON output. When
+     * {@code true} (default), the top level JSON object contains a single field
+     * named after the XML root element. If set to {@code false}, the children of
+     * the XML root element are written directly into the top level JSON object.
+     */
     private boolean wrapRoot = true;
     private boolean prettyPrint = false;
     private boolean preserveNamespaces = true;
@@ -39,6 +45,22 @@ public class MappingConfig {
     }
 
     public void setWrapRoot(boolean wrapRoot) {
+        this.wrapRoot = wrapRoot;
+    }
+
+    /**
+     * Alias for {@link #isWrapRoot()} to improve readability when using the
+     * builder API.
+     */
+    public boolean isWrapRootElement() {
+        return wrapRoot;
+    }
+
+    /**
+     * Alias for {@link #setWrapRoot(boolean)}. Allows configuring the behaviour
+     * using a more descriptive name.
+     */
+    public void setWrapRootElement(boolean wrapRoot) {
         this.wrapRoot = wrapRoot;
     }
 

--- a/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -70,6 +70,22 @@ public class XmlToJsonStreamer {
         public Builder jsonFactory(JsonFactory f) { this.jsonFactory = f; return this; }
         public Builder xmlInputFactory(XMLInputFactory f) { this.xmlInputFactory = f; return this; }
         public Builder mappingConfig(MappingConfig c) { this.mappingConfig = c; return this; }
+        /**
+         * Configure whether the resulting JSON should include the XML root element
+         * as a wrapper object.
+         */
+        public Builder wrapRootElement(boolean b) {
+            this.mappingConfig.setWrapRootElement(b);
+            return this;
+        }
+
+        /**
+         * Enable human readable pretty printed JSON output.
+         */
+        public Builder prettyPrint(boolean b) {
+            this.mappingConfig.setPrettyPrint(b);
+            return this;
+        }
 
         public XmlToJsonStreamer build() throws IOException {
             if (jsonFactory == null) {

--- a/src/test/java/com/example/transformer/BuilderOptionsTest.java
+++ b/src/test/java/com/example/transformer/BuilderOptionsTest.java
@@ -1,0 +1,34 @@
+package com.example.transformer;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BuilderOptionsTest {
+
+    @Test
+    public void unwrapRootWithBuilder() throws Exception {
+        XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+                .wrapRootElement(false)
+                .build();
+        ByteArrayInputStream in = new ByteArrayInputStream("<a>v</a>".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        streamer.transform(in, out);
+        assertEquals("\"v\"", out.toString());
+    }
+
+    @Test
+    public void prettyPrintWithBuilder() throws Exception {
+        XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+                .prettyPrint(true)
+                .build();
+        ByteArrayInputStream in = new ByteArrayInputStream("<x><y>z</y></x>".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        streamer.transform(in, out);
+        assertTrue(out.toString().contains("\n"));
+    }
+}


### PR DESCRIPTION
## Summary
- document JSON formatting options in README
- add alias methods for `wrapRootElement` in MappingConfig
- expose `wrapRootElement` and `prettyPrint` via builder
- test the new builder methods

## Testing
- `mvn -q -Dtest=BuilderOptionsTest test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683be8cef2fc832e9bf000cf5e6d6660