### PR TITLE
Fix application context startup in tests

### DIFF
--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/HomeController.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/HomeController.java
@@ -15,11 +15,12 @@ public class HomeController {
 
     private static final Logger logger = LoggerFactory.getLogger(HomeController.class);
 
+    @Nullable
     private final BuildProperties buildProperties;
     @Nullable
     private final GitProperties gitProperties;
 
-    public HomeController(BuildProperties buildProperties, @Nullable GitProperties gitProperties) {
+    public HomeController(@Nullable BuildProperties buildProperties, @Nullable GitProperties gitProperties) {
         this.buildProperties = buildProperties;
         this.gitProperties = gitProperties;
     }


### PR DESCRIPTION
## Summary
- make `BuildProperties` optional in `HomeController` so tests run without build info files

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c0549ca70832e8fb9832295352ed8