### PR TITLE
Fix duplicate AuditService bean

### DIFF
--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditConfiguration.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditConfiguration.java
@@ -13,8 +13,4 @@ public class AuditConfiguration {
         return new InMemoryAuditStore(props.getHistorySize());
     }
 
-    @Bean
-    public AuditService auditService(AuditProperties props) {
-        return new AuditService(props);
-    }
 }


### PR DESCRIPTION
## Summary
- remove AuditService bean method from `AuditConfiguration`

## Testing
- `mvn -q -pl xml-json-spring-boot-starter test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c06c17f54832e9070adce4de17ffc