### PR TITLE
Fix Spring tests and dependency

### DIFF
--- a/xml-json-core/pom.xml
+++ b/xml-json-core/pom.xml
@@ -32,6 +32,14 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <!-- Include the Spring Boot starter on the test classpath so that
+             tests can load the application context from the starter module -->
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>xml-json-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/xml-json-spring-boot-starter/src/test/java/com/example/transformer/AuditControllerMockMvcTest.java
+++ b/xml-json-spring-boot-starter/src/test/java/com/example/transformer/AuditControllerMockMvcTest.java
@@ -3,24 +3,24 @@ package com.example.transformer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@WebMvcTest(controllers = AuditController.class)
 public class AuditControllerMockMvcTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
+    @MockBean
     private AuditService auditService;
+
+    @MockBean
+    private AuditProperties auditProperties;
 
     @BeforeEach
     public void setup() {

--- a/xml-json-spring-boot-starter/src/test/java/com/example/transformer/LargeStreamTest.java
+++ b/xml-json-spring-boot-starter/src/test/java/com/example/transformer/LargeStreamTest.java
@@ -22,7 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
-@SpringBootTest
+@SpringBootTest(classes = XmlJsonTransformerApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 public class LargeStreamTest {
 

--- a/xml-json-spring-boot-starter/src/test/java/com/example/transformer/TransformControllerMockMvcTest.java
+++ b/xml-json-spring-boot-starter/src/test/java/com/example/transformer/TransformControllerMockMvcTest.java
@@ -2,20 +2,27 @@ package com.example.transformer;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import com.example.transformer.XmlToJsonStreamer;
+import com.example.transformer.AuditService;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(controllers = TransformController.class)
 public class TransformControllerMockMvcTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private XmlToJsonStreamer xmlToJsonStreamer;
+
+    @MockBean
+    private AuditService auditService;
 
     @Test
     public void validXml() throws Exception {


### PR DESCRIPTION
## Summary
- allow core tests to load the starter when required
- slice MVC controller tests and mock collaborators
- specify application class for integration test

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c0ea92b7c832e9e077a5c8b1a209c