### PR TITLE
Restore Unicode surrogate configuration

### DIFF
--- a/xml-json-core/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/xml-json-core/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -33,9 +33,7 @@ public class XmlToJsonStreamer {
     public XmlToJsonStreamer(MappingConfig config) throws IOException {
         this(JsonFactory.builder()
                 .configure(JsonWriteFeature.ESCAPE_NON_ASCII, config.isEscapeNonAscii())
-                // Older Jackson versions (as used by Spring Boot) may not expose
-                // the COMBINE_UNICODE_SURROGATES_IN_UTF8 feature. Simply omit
-                // the configuration so the code runs with any Jackson version.
+                .configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8, true)
                 .build(),
              XMLInputFactory.newFactory(),
              config);
@@ -86,10 +84,7 @@ public class XmlToJsonStreamer {
             if (jsonFactory == null) {
                 jsonFactory = JsonFactory.builder()
                         .configure(JsonWriteFeature.ESCAPE_NON_ASCII, mappingConfig.isEscapeNonAscii())
-                        // The COMBINE_UNICODE_SURROGATES_IN_UTF8 feature does not
-                        // exist on older Jackson versions, so avoid configuring it
-                        // to retain compatibility with the version included in
-                        // Spring Boot.
+                        .configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8, true)
                         .build();
             }
             if (xmlInputFactory == null) {
@@ -117,9 +112,7 @@ public class XmlToJsonStreamer {
         String rootName = buildQName(reader.getPrefix(), reader.getLocalName());
         JsonGenerator g = jsonFactory.createGenerator(jsonOutput);
 
-        // Configure features that exist across Jackson versions. The
-        // COMBINE_UNICODE_SURROGATES_IN_UTF8 feature is optional and
-        // may not be present in the Jackson version provided by Spring Boot.
+        g.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
         g.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), config.isEscapeNonAscii());
 
         if (config.isPrettyPrint()) {
@@ -167,8 +160,7 @@ public class XmlToJsonStreamer {
 
         ByteArrayOutputStream buf = new ByteArrayOutputStream(64);
         JsonGenerator tmp = jsonFactory.createGenerator(buf);
-        // COMBINE_UNICODE_SURROGATES_IN_UTF8 may not be supported; use defaults
-        // that work on any Jackson version.
+        tmp.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
         tmp.setPrettyPrinter(new CompactPrettyPrinter());
 
         while (reader.hasNext()) {
@@ -230,7 +222,7 @@ public class XmlToJsonStreamer {
         String rootName = buildQName(reader.getPrefix(), reader.getLocalName());
         JsonGenerator g = jsonFactory.createGenerator(jsonWriter);
 
-        // Only configure features that are guaranteed to exist
+        g.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
         g.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), config.isEscapeNonAscii());
 
         if (config.isPrettyPrint()) {

--- a/xml-json-core/src/main/java/com/example/transformer/XmlToJsonStreamerBuilder.java
+++ b/xml-json-core/src/main/java/com/example/transformer/XmlToJsonStreamerBuilder.java
@@ -29,8 +29,7 @@ public final class XmlToJsonStreamerBuilder {
         if (jsonFactory == null) {
             jsonFactory = JsonFactory.builder()
                     .configure(JsonWriteFeature.ESCAPE_NON_ASCII, false)
-                    // Skip configuring COMBINE_UNICODE_SURROGATES_IN_UTF8 for
-                    // compatibility with older Jackson versions.
+                    .configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8, true)
                     .build();
         }
         if (xmlFactory == null) {


### PR DESCRIPTION
## Summary
- enable `COMBINE_UNICODE_SURROGATES_IN_UTF8` on all JsonFactories
- configure generators with the unicode surrogate feature

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c14f1e184832e82ffd173444f3aa0