### PR TITLE
Fix tests by enabling Byte Buddy experimental mode

### DIFF
--- a/xml-json-spring-boot-starter/pom.xml
+++ b/xml-json-spring-boot-starter/pom.xml
@@ -65,6 +65,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <argLine>-Dnet.bytebuddy.experimental=true</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>


### PR DESCRIPTION
## Summary
- add maven-surefire-plugin config to pass `-Dnet.bytebuddy.experimental=true`

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c1875a7b0832ebb8fedec4ae3e18a