### PR TITLE
Fix emoji encoding

### DIFF
--- a/xml-json-core/src/main/java/com/example/transformer/XmlToJsonStreamer.java
+++ b/xml-json-core/src/main/java/com/example/transformer/XmlToJsonStreamer.java
@@ -33,6 +33,7 @@ public class XmlToJsonStreamer {
     public XmlToJsonStreamer(MappingConfig config) throws IOException {
         this(JsonFactory.builder()
                 .configure(JsonWriteFeature.ESCAPE_NON_ASCII, config.isEscapeNonAscii())
+                .configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8, true)
                 .build(),
              XMLInputFactory.newFactory(),
              config);
@@ -83,6 +84,7 @@ public class XmlToJsonStreamer {
             if (jsonFactory == null) {
                 jsonFactory = JsonFactory.builder()
                         .configure(JsonWriteFeature.ESCAPE_NON_ASCII, mappingConfig.isEscapeNonAscii())
+                        .configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8, true)
                         .build();
             }
             if (xmlInputFactory == null) {
@@ -111,6 +113,7 @@ public class XmlToJsonStreamer {
         JsonGenerator g = jsonFactory.createGenerator(jsonOutput);
 
         g.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), config.isEscapeNonAscii());
+        g.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
 
         if (config.isPrettyPrint()) {
             g.useDefaultPrettyPrinter();
@@ -157,6 +160,8 @@ public class XmlToJsonStreamer {
 
         ByteArrayOutputStream buf = new ByteArrayOutputStream(64);
         JsonGenerator tmp = jsonFactory.createGenerator(buf);
+        tmp.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), config.isEscapeNonAscii());
+        tmp.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
         tmp.setPrettyPrinter(new CompactPrettyPrinter());
 
         while (reader.hasNext()) {
@@ -219,6 +224,7 @@ public class XmlToJsonStreamer {
         JsonGenerator g = jsonFactory.createGenerator(jsonWriter);
 
         g.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), config.isEscapeNonAscii());
+        g.configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8.mappedFeature(), true);
 
         if (config.isPrettyPrint()) {
             g.useDefaultPrettyPrinter();

--- a/xml-json-core/src/main/java/com/example/transformer/XmlToJsonStreamerBuilder.java
+++ b/xml-json-core/src/main/java/com/example/transformer/XmlToJsonStreamerBuilder.java
@@ -29,6 +29,7 @@ public final class XmlToJsonStreamerBuilder {
         if (jsonFactory == null) {
             jsonFactory = JsonFactory.builder()
                     .configure(JsonWriteFeature.ESCAPE_NON_ASCII, false)
+                    .configure(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8, true)
                     .build();
         }
         if (xmlFactory == null) {

--- a/xml-json-core/src/test/java/com/example/transformer/EscapeNonAsciiTest.java
+++ b/xml-json-core/src/test/java/com/example/transformer/EscapeNonAsciiTest.java
@@ -1,0 +1,27 @@
+package com.example.transformer;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EscapeNonAsciiTest {
+
+    @Test
+    public void escapeAllNonAscii() throws Exception {
+        MappingConfig cfg = new MappingConfig();
+        cfg.setEscapeNonAscii(true);
+        XmlToJsonStreamer streamer = XmlToJsonStreamer.builder()
+                .mappingConfig(cfg)
+                .build();
+        String xml = "<msg>π 🐨</msg>";
+        ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        streamer.transform(in, out);
+        assertEquals("{\"msg\":\"\\u03C0 \\uD83D\\uDC28\"}", out.toString(StandardCharsets.UTF_8));
+    }
+}

--- a/xml-json-core/src/test/java/com/example/transformer/UnicodeTest.java
+++ b/xml-json-core/src/test/java/com/example/transformer/UnicodeTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,5 +27,23 @@ public class UnicodeTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         streamer.transform(in, out);
         assertEquals("{\"msg\":\"🐨\"}", new String(out.toByteArray(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void utf8ReaderWriter() throws Exception {
+        String xml = "<msg>🐨</msg>";
+        StringReader reader = new StringReader(xml);
+        StringWriter writer = new StringWriter();
+        streamer.transform(reader, writer);
+        assertEquals("{\"msg\":\"🐨\"}", writer.toString());
+    }
+
+    @Test
+    public void diverseCharacters() throws Exception {
+        String xml = "<msg>áπ🐨漢字</msg>";
+        ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        streamer.transform(in, out);
+        assertEquals("{\"msg\":\"áπ🐨漢字\"}", new String(out.toByteArray(), StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
## Summary
- ensure Unicode emoji appear unescaped in JSON
- test UTF-8 handling for Reader/Writer path and mixed characters
- verify escaping when non‑ASCII escaping enabled

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c48044064832eb5f220979654d48b