### PR TITLE
Improve audit history pagination

### DIFF
--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditController.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditController.java
@@ -28,9 +28,11 @@ public class AuditController {
     @GetMapping(value = "/audit", produces = MediaType.TEXT_HTML_VALUE)
     public String list(@RequestParam(name = "page", defaultValue = "0") int page, Model model) {
         logger.info("Audit list requested - page {}", page);
-        model.addAttribute("entries", service.page(page, props.getPageSize()));
+        int pageSize = props.getPageSize();
+        model.addAttribute("entries", service.page(page, pageSize));
         model.addAttribute("page", page);
-        model.addAttribute("pageSize", props.getPageSize());
+        model.addAttribute("pageSize", pageSize);
+        model.addAttribute("totalPages", (service.count() + pageSize - 1) / pageSize);
         return "auditList";
     }
 

--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditService.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditService.java
@@ -59,6 +59,10 @@ public class AuditService {
         return null;
     }
 
+    public int count() {
+        return history.size();
+    }
+
     /**
      * Clears all stored audit entries. Used in tests.
      */

--- a/xml-json-spring-boot-starter/src/main/resources/templates/auditList.html
+++ b/xml-json-spring-boot-starter/src/main/resources/templates/auditList.html
@@ -56,10 +56,23 @@
         </tbody>
     </table>
 
-    <div class="mt-4">
-        <a th:if="${page > 0}" th:href="@{'/audit?page=' + ${page - 1}}" class="btn btn-secondary">Previous</a>
-        <a th:if="${entries.size() == pageSize}" th:href="@{'/audit?page=' + ${page + 1}}" class="btn btn-secondary">Next</a>
-    </div>
+    <nav aria-label="Page navigation" class="mt-4">
+        <ul class="pagination">
+            <li class="page-item" th:classappend="${page == 0} ? 'disabled'">
+                <a class="page-link" th:href="@{'/audit?page=' + ${page - 1}}" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            <li class="page-item" th:each="i : ${#numbers.sequence(0, totalPages - 1)}" th:classappend="${i == page} ? 'active'">
+                <a class="page-link" th:text="${i + 1}" th:href="@{'/audit?page=' + ${i}}"></a>
+            </li>
+            <li class="page-item" th:classappend="${page >= totalPages - 1} ? 'disabled'">
+                <a class="page-link" th:href="@{'/audit?page=' + ${page + 1}}" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
@@ -69,7 +82,8 @@
             return {
                 entries: [[${entries}]],
                 page: [[${page}]],
-                pageSize: [[${pageSize}]]
+                pageSize: [[${pageSize}]],
+                totalPages: [[${totalPages}]]
             };
         },
         methods: {


### PR DESCRIPTION
## Summary
- compute total page count in `AuditController`
- expose a `count` method in `AuditService`
- add Bootstrap pagination controls to the audit history page

## Testing
- `mvn -q -e -DskipTests=false test` *(fails: `ProjectBuildingException` due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68846581a7d0832e8dfe9544f17d134b