### PR TITLE
Implement audit search feature

### DIFF
--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditController.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditController.java
@@ -56,4 +56,13 @@ public class AuditController {
         model.addAttribute("entry", entry);
         return "auditDetail";
     }
+
+    @GetMapping(value = "/audit/search", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public List<AuditEntrySummary> search(@RequestParam("q") String query) {
+        logger.info("Audit search for '{}'", query);
+        return service.search(query).stream()
+                .map(AuditEntrySummary::new)
+                .toList();
+    }
 }

--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditService.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditService.java
@@ -64,6 +64,25 @@ public class AuditService {
     }
 
     /**
+     * Returns all audit entries whose XML or JSON payload contains the given text.
+     */
+    public List<AuditEntry> search(String text) {
+        String lower = text.toLowerCase();
+        return history.stream()
+                .filter(e -> containsIgnoreCase(e, lower))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private boolean containsIgnoreCase(AuditEntry e, String lower) {
+        try {
+            return e.getXml().toLowerCase().contains(lower)
+                    || e.getJson().toLowerCase().contains(lower);
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+
+    /**
      * Clears all stored audit entries. Used in tests.
      */
     public void clear() {

--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditStore.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/AuditStore.java
@@ -6,4 +6,8 @@ public interface AuditStore {
     void save(AuditEntry entry);
     List<AuditEntry> page(int page, int size);
     AuditEntry get(long id);
+    /**
+     * Returns all audit entries whose XML or JSON payload contains the given text.
+     */
+    List<AuditEntry> search(String text);
 }

--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/FileAuditStore.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/FileAuditStore.java
@@ -103,4 +103,21 @@ public class FileAuditStore implements AuditStore {
         }
         return null;
     }
+
+    @Override
+    public synchronized List<AuditEntry> search(String text) {
+        String lower = text.toLowerCase();
+        return history.stream()
+                .filter(e -> containsIgnoreCase(e, lower))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private boolean containsIgnoreCase(AuditEntry e, String lower) {
+        try {
+            return e.getXml().toLowerCase().contains(lower)
+                    || e.getJson().toLowerCase().contains(lower);
+        } catch (IOException ex) {
+            return false;
+        }
+    }
 }

--- a/xml-json-spring-boot-starter/src/main/java/com/example/transformer/InMemoryAuditStore.java
+++ b/xml-json-spring-boot-starter/src/main/java/com/example/transformer/InMemoryAuditStore.java
@@ -39,4 +39,21 @@ public class InMemoryAuditStore implements AuditStore {
         }
         return null;
     }
+
+    @Override
+    public List<AuditEntry> search(String text) {
+        String lower = text.toLowerCase();
+        return history.stream()
+                .filter(e -> containsIgnoreCase(e, lower))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private boolean containsIgnoreCase(AuditEntry e, String lower) {
+        try {
+            return e.getXml().toLowerCase().contains(lower)
+                    || e.getJson().toLowerCase().contains(lower);
+        } catch (IOException ex) {
+            return false;
+        }
+    }
 }

--- a/xml-json-spring-boot-starter/src/main/resources/templates/auditList.html
+++ b/xml-json-spring-boot-starter/src/main/resources/templates/auditList.html
@@ -30,7 +30,10 @@
             <li class="breadcrumb-item active" aria-current="page">Audit History</li>
         </ol>
     </nav>
-    <h2>Audit History</h2>
+    <div class="d-flex justify-content-between align-items-center">
+        <h2>Audit History</h2>
+        <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#searchModal">Search</button>
+    </div>
     <p>List of all transformation requests logged by the service.</p>
 
     <table class="table table-striped table-hover mt-3">
@@ -75,6 +78,40 @@
     </nav>
 </div>
 
+<!-- Search Modal -->
+<div class="modal fade" id="searchModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Search Audit Entries</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="text" class="form-control" v-model="searchQuery" @keyup.enter="performSearch" placeholder="Search...">
+                <div class="mt-3" v-if="searchResults.length">
+                    <table class="table table-sm">
+                        <thead>
+                        <tr><th>ID</th><th>Client IP</th><th>Request Time</th></tr>
+                        </thead>
+                        <tbody>
+                        <tr v-for="r in searchResults" :key="r.id">
+                            <td><a :href="'/audit/' + r.id">{{ r.id }}</a></td>
+                            <td>{{ r.clientIp }}</td>
+                            <td>{{ formatTime(r.requestTime) }}</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p v-else class="text-muted mt-3" v-if="searchPerformed">No results</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" @click="performSearch">Search</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script th:inline="javascript">
     const app = Vue.createApp({
@@ -83,7 +120,10 @@
                 entries: [[${entries}]],
                 page: [[${page}]],
                 pageSize: [[${pageSize}]],
-                totalPages: [[${totalPages}]]
+                totalPages: [[${totalPages}]],
+                searchQuery: '',
+                searchResults: [],
+                searchPerformed: false
             };
         },
         methods: {
@@ -95,6 +135,15 @@
                 const resp = await fetch(`/audit/api?page=${this.page}`);
                 if (resp.ok) {
                     this.entries = await resp.json();
+                }
+            },
+            async performSearch() {
+                this.searchPerformed = true;
+                const resp = await fetch(`/audit/search?q=${encodeURIComponent(this.searchQuery)}`);
+                if (resp.ok) {
+                    this.searchResults = await resp.json();
+                } else {
+                    this.searchResults = [];
                 }
             }
         },


### PR DESCRIPTION
## Summary
- allow searching audit history by text
- expose `/audit/search` endpoint returning matching entries
- add search support in memory and file stores
- integrate a search modal on the audit page

## Testing
- `mvn -q -pl xml-json-spring-boot-starter test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6884693e3148832ea1e662ed12e34b9a